### PR TITLE
Add the redeem all functionality

### DIFF
--- a/contracts/CToken.sol
+++ b/contracts/CToken.sol
@@ -987,8 +987,6 @@ abstract contract CToken is CTokenInterface, Exponential, TokenErrorReporter {
         internal
         returns (uint256)
     {
-        require(redeemAmountIn > 0, "CT15");
-
         RedeemLocalVars memory vars;
 
         SupplySnapshot storage supplySnapshot = accountTokens[redeemer];
@@ -1062,7 +1060,12 @@ abstract contract CToken is CTokenInterface, Exponential, TokenErrorReporter {
             );
         }
 
-        vars.redeemAmount = redeemAmountIn;
+        if (redeemAmountIn == 0) {
+            vars.redeemAmount = supplySnapshot.underlyingAmount;
+            redeemAmountIn = supplySnapshot.underlyingAmount;
+        } else {
+            vars.redeemAmount = redeemAmountIn;
+        }
 
         if (isTropykusInterestRateModel) {
             (, Exp memory num) = mulExp(


### PR DESCRIPTION
	I added the possibility to redeem all the underlying liquidity by implementing the zero amount convention used in the previous pay-all te debt functionality. Note: the error CT15 was deleted.