### PR TITLE
Add oracle failure blocking

### DIFF
--- a/contracts/ComptrollerG6.sol
+++ b/contracts/ComptrollerG6.sol
@@ -308,6 +308,10 @@ contract ComptrollerG6 is
         minter;
         mintAmount;
 
+        if (oracle.getUnderlyingPrice(CToken(cToken)) == 0) {
+            return uint256(Error.PRICE_ERROR);
+        }
+
         if (!markets[cToken].isListed) {
             return uint256(Error.MARKET_NOT_LISTED);
         }
@@ -361,6 +365,9 @@ contract ComptrollerG6 is
             return allowed;
         }
 
+        if (oracle.getUnderlyingPrice(CToken(cToken)) == 0) {
+            return uint256(Error.PRICE_ERROR);
+        }
         // Keep the flywheel moving
         updateCompSupplyIndex(cToken);
         distributeSupplierComp(cToken, redeemer, false);
@@ -534,6 +541,10 @@ contract ComptrollerG6 is
         payer;
         borrower;
         repayAmount;
+
+        if (oracle.getUnderlyingPrice(CToken(cToken)) == 0) {
+            return uint256(Error.PRICE_ERROR);
+        }
 
         if (!markets[cToken].isListed) {
             return uint256(Error.MARKET_NOT_LISTED);

--- a/contracts/mocks/MockPriceProviderMoC.sol
+++ b/contracts/mocks/MockPriceProviderMoC.sol
@@ -58,4 +58,17 @@ contract MockPriceProviderMoC {
             uint256(rbtcPrice)
         );
     }
+
+    /**
+     * @notice Set a new has state
+     * @param _has bool value for new has state
+     */
+    function setHasState(bool _has) public {
+        require(
+            msg.sender == guardian,
+            "MockPriceProviderMoC: only guardian may set the address"
+        );
+
+        has = _has;
+    }
 }

--- a/instructions
+++ b/instructions
@@ -10,6 +10,7 @@ load = async() => {
     crbtc = await ethers.getContractAt('CRBTC', cRBTC, dep);
     csat = await ethers.getContractAt('CRBTC', cSAT, dep);
     priceOracleProxy = await ethers.getContractAt('PriceOracleProxy', PriceOracleProxy, dep);
+    rbtcOracle = await ethers.getContractAt('MockPriceProviderMoC', RBTCOracle, dep);
     whitelist = await ethers.getContractAt('Whitelist', Whitelist, dep);
 }
 


### PR DESCRIPTION
	After consulting an oracle about the price of a token and receiving an error, any action (mint, redeem, borrow, repayBorrow) is blocked.